### PR TITLE
Fixed Undefined offset: 1 exception in date.

### DIFF
--- a/xapi-store/src/XapiDate.php
+++ b/xapi-store/src/XapiDate.php
@@ -14,7 +14,7 @@ class XapiDate
         try {
             list($seconds, $micro) = explode('.', microtime(true));
             // We need 4 digits precision.
-            $micro = substr($micro.'000', 0, 4);
+            $micro = substr($micro . '000', 0, 4);
         } catch (\Exception $e) {
             // $micro may be missing.
             $seconds = microtime(true);
@@ -36,6 +36,9 @@ class XapiDate
         // Timezone is taken into account.
         $timestamp = strtotime($isoDate);
 
+        // Append T00:00:00 in case the date string doesn't contain T
+        $isoDate = (stripos($isoDate, 'T') === false) ? $isoDate . 'T00:00:00' : $isoDate;
+
         // We need to extract microseconds from the original ISO date.
         list($date, $time) = explode('T', $isoDate);
 
@@ -47,11 +50,11 @@ class XapiDate
         } elseif (strpos($time, 'Z') !== false) {
             list($time) = explode('Z', $time);
         }
-        
+
         // Extract and normalize microseconds (4 digits precision).
         try {
             list($seconds, $micro) = explode('.', $time);
-            $micro = substr($micro.'000', 0, 4);
+            $micro = substr($micro . '000', 0, 4);
         } catch (\Exception $e) {
             $micro = '0000';
         }


### PR DESCRIPTION
Issue was that if we pass `2020-02-02` in `since` the Trax LRS was failing to respond and was expecting `T` inside date. Which was raising the exception. This has been fixed in this PR.